### PR TITLE
Add setuptools dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -21,6 +21,7 @@ requirements:
     - python >=3.6
     - numpy >=1.14
     - pandas >=0.24
+    - setuptools
 
 test:
   imports:


### PR DESCRIPTION
A build of one of my packages, which depends on `xarray`, [failed](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=103605&view=logs&j=1bf226d3-0e2f-52d8-fa93-7d9e633347b3&t=ec8d466d-e3b4-5115-4f06-222398f91e6c) because `setuptools` doesn't get installed alongside `xarray`, yet `xarray` depends on `setuptools`. On the conda-forge gitter channel it was then suggested that the `xarray` recipe should explicitly list `setuptools` as a run dependency. This is what this PR does.